### PR TITLE
BSP-120 | Crash when Nats tries to connect to an invalid url

### DIFF
--- a/run
+++ b/run
@@ -21,12 +21,16 @@ function docker-push() {
     docker push jwalab/airlock
 }
 
-function start() {
+function start-node() {
     node dist/index.js
 }
 
 function dev() {
     npm run dev
+}
+
+function tests() {
+    npm run test
 }
 
 function build() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,63 @@
-import { connect } from "nats";
+import { connect, NatsConnection } from "nats";
 import express, { json } from "express";
 import cors from "cors";
-
 import restToNatsBridge from "./middlewares/natsToRestBridge";
 import serveOpenAPIDocs from "./middlewares/openAPIDocs";
 import { HTTP_PORT, NATS_URL } from "./config";
 import errorHandlingMiddleware from "./middlewares/errorHandler";
 import authorizationMiddleware from "./middlewares/authorization";
+import { drain } from "./lib/nats/nats";
+
+let natsConnection: NatsConnection;
 
 async function init() {
-    const natsConnection = await connect({
-        servers: NATS_URL
-    });
+    async function shutdown(exitCode: number): Promise<void> {
+        try {
+            await drain(natsConnection);
+            process.exit(exitCode);
+        } catch (e) {
+            console.log(`[AIRLOCK] Unable to drain Nats connection, shutting down . . .`);
+        } finally {
+            process.exit(1);
+        }
+    }
 
-    const app = express();
+    try {
+        natsConnection = await connect({
+            servers: NATS_URL
+        });
 
-    app.use(json());
+        const app = express();
 
-    app.get("/docs", cors(), serveOpenAPIDocs(natsConnection));
-    app.use("/", cors(), authorizationMiddleware);
-    app.use("/api", cors(), restToNatsBridge(natsConnection));
-    app.use(errorHandlingMiddleware);
+        app.use(json());
 
-    console.info(`[AIRLOCK] Connected to Nats ${natsConnection.getServer()}`);
+        app.get("/docs", cors(), serveOpenAPIDocs(natsConnection));
+        app.use("/", cors(), authorizationMiddleware);
+        app.use("/api", cors(), restToNatsBridge(natsConnection));
+        app.use(errorHandlingMiddleware);
 
-    app.listen(HTTP_PORT, () => {
-        console.log(`[AIRLOCK] Airlock listening on port ${HTTP_PORT}`);
-    });
+        console.info(
+            `[AIRLOCK] Connected to Nats ${natsConnection.getServer()}`
+        );
+
+        app.listen(HTTP_PORT, () => {
+            console.log(`[AIRLOCK] Airlock listening on port ${HTTP_PORT}`);
+        });
+
+        process.on("SIGINT", () => {
+            console.log("[AIRLOCK] Gracefully shutting down...");
+            shutdown(0);
+        });
+
+        process.on("SIGTERM", () => {
+            console.log("[AIRLOCK] Gracefully shutting down...");
+            shutdown(0);
+        });
+    } catch (error) {
+        console.error(`[AIRLOCK] Airlock exited with error: ${error}`);
+        console.error(error);
+        shutdown(1);
+    }
 }
 
 init();

--- a/src/lib/nats/nats.ts
+++ b/src/lib/nats/nats.ts
@@ -1,0 +1,13 @@
+import { NatsConnection } from "nats";
+
+export function drain(natsConnection: NatsConnection): Promise<void> {
+    if (!natsConnection) {
+        console.log(`[AIRLOCK] No Nats connection to drain.`);
+        return Promise.resolve();
+    }
+
+    console.log(
+        `[AIRLOCK] Draining connection to NATS server ${natsConnection.getServer()}`
+    );
+    return natsConnection.drain();
+}


### PR DESCRIPTION
- Nats doesn't crash Airlock anymore on failure.
- Graceful shutdown added.
- "start" function starting the node server is now "start-node" in the run script.
- "tests" function added in run script.