### PR TITLE
BSP-124: Set Airlock URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "airlock",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Airlock is an HTTP<->NATS bridge granting access to the JWA platform's resources",
     "main": "dist/index.js",
     "directories": {

--- a/run
+++ b/run
@@ -33,4 +33,8 @@ function build() {
     npm run build
 }
 
+function test() {
+    npm run test
+}
+
 "$@"

--- a/src/middlewares/openAPIDocs.ts
+++ b/src/middlewares/openAPIDocs.ts
@@ -18,6 +18,7 @@ export default function serveOpenAPIDocs(natsConnection: NatsConnection) {
         const docsInbox = createInbox();
 
         const docsPromise = gatherDocs(
+            req,
             natsConnection.subscribe(docsInbox),
             DOCS_GATHERING_TIMEOUT
         );
@@ -32,7 +33,7 @@ export default function serveOpenAPIDocs(natsConnection: NatsConnection) {
     };
 }
 
-async function gatherDocs(subscription: Subscription, timeout: number) {
+async function gatherDocs(req: Request, subscription: Subscription, timeout: number) {
     return new Promise((resolve, reject) => {
         (async () => {
             const openApiBuilder = new OpenApiBuilder();
@@ -49,6 +50,7 @@ async function gatherDocs(subscription: Subscription, timeout: number) {
                     ) as OpenAPIV3.Document;
 
                     openApiBuilder
+                        .setUrl(req)
                         .addPaths(openApiDoc.paths)
                         .addComponents(openApiDoc.components || {})
                         .addTags(openApiDoc.tags || []);

--- a/src/openApi/OpenApiBuilder.ts
+++ b/src/openApi/OpenApiBuilder.ts
@@ -1,5 +1,6 @@
 import { OpenAPIV3 } from "openapi-types";
 import { merge } from "lodash";
+import { Request } from "express";
 
 import OpenAPIMetadata from "./OpenApiMetadata.json";
 
@@ -8,6 +9,17 @@ export default class SwaggerBuilder {
 
     constructor() {
         this.swagger = JSON.parse(JSON.stringify(OpenAPIMetadata));
+    }
+
+    setUrl(req: Request): this {
+        this.swagger.servers = [
+            {
+                url: `${req.protocol}://${req.headers.host}/api`,
+                description: `Services available via this Airlock`
+            }
+        ];
+
+        return this;
     }
 
     addPaths(paths: OpenAPIV3.PathsObject): this {

--- a/src/openApi/OpenApiMetadata.json
+++ b/src/openApi/OpenApiMetadata.json
@@ -1,6 +1,6 @@
 {
     "openapi": "3.0.3",
-    "servers": [{ "url": "/api" }],
+    "servers": [],
     "info": {
         "description": "PlayTiX | JWA Platform API Definition",
         "version": "0.0.1",

--- a/tests/airlock-docs.test.js
+++ b/tests/airlock-docs.test.js
@@ -24,5 +24,11 @@ describe("Given Airlock is running", () => {
                 "/service-b"
             ]);
         });
+
+        it("Then sets the server url", () => {
+            expect(docs.servers.find((server) => {
+                return server.url === `${ SERVER_URL }/api`
+            }));
+        });
     });
 });


### PR DESCRIPTION
- When importing the OpenAPI docs from a url, the baseUrl is automatically set to that url