### PR TITLE
[WIP][BSP-138][BSP-139]health-check endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,8 @@ module.exports = {
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "prettier"
-    ]
+    ],
+    "env": {
+        "jest": true
+    }
 };

--- a/README.md
+++ b/README.md
@@ -26,19 +26,14 @@ docker-compose up
 node tests/mocks/mockService.js
 ```
 
-3. Then, set the following environment variables and start airlock
+3. Start airlock
 
 ```
-AUTH_URL=localhost:8999
-AUTH_PROTOCOL=http
-SECURE=false
-NATS_URL=nats://localhost:4222
-
-npm run dev
+./run dev
 ```
 
 4. Finally, run the tests
 
 ```
-npm run test
+./run test
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "airlock",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Airlock is an HTTP<->NATS bridge granting access to the JWA platform's resources",
     "main": "dist/index.js",
     "directories": {

--- a/src/lib/nats/nats.ts
+++ b/src/lib/nats/nats.ts
@@ -1,5 +1,40 @@
 import { NatsConnection } from "nats";
 
+export class NatsConnectionMonitor {
+    private connected = true;
+
+    constructor(nc: NatsConnection, connectionLostCallback: () => void) {
+        this.handleStatus(nc);
+        this.handleClosing(nc, connectionLostCallback);
+    }
+
+    public isConnected(): boolean {
+        return this.connected;
+    }
+
+    private async handleStatus(nc: NatsConnection) {
+        for await (const status of nc.status()) {
+            console.info(`[AIRLOCK] nats event : ${status.type} => ${JSON.stringify(status.data)}`);
+
+            switch (status.type) {
+                case "disconnect" :
+                    this.connected = false;
+                    break;
+                case "reconnect" :
+                    this.connected = true;
+                    break;
+            }
+        }
+    }
+
+    private handleClosing(nc: NatsConnection, connectionLostCallback: () => void) {
+        nc.closed().finally(() => {
+            console.error("[AIRLOCK] nats connection definitely closed");
+            connectionLostCallback();
+        })
+    }
+}
+
 export function drain(natsConnection: NatsConnection): Promise<void> {
     if (!natsConnection) {
         console.log(`[AIRLOCK] No Nats connection to drain.`);

--- a/src/middlewares/healthCheck.ts
+++ b/src/middlewares/healthCheck.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from "express";
+import { NatsConnectionMonitor } from "../lib/nats/nats";
+
+export default function healthCheck(ncMonitor: NatsConnectionMonitor) {
+    return async function (req: Request, res: Response): Promise<void> {
+        if (ncMonitor.isConnected()) {
+            res.send("ok");
+        } else {
+            res.status(500).send("ko");
+        }
+    };
+}

--- a/tests/airlock.test.js
+++ b/tests/airlock.test.js
@@ -17,6 +17,13 @@ describe("Given Airlock is running", () => {
         axiosConfig.headers.Authorization = `Bearer ${await utils.generateTestToken()}`;
     });
 
+    describe("When I try to access the health check endpoint", () => {
+        it("Then replies with a 200 status code", async () => {
+            const response = await axios.get(`http://localhost:8000/health-check`);
+            expect(response.status).toEqual(200);
+        });
+    });
+
     describe("When I try to access to the mock service with no token", () => {
         it("Then replies with a status code 401", async () => {
             try {


### PR DESCRIPTION
The AWS load balancer requires a health check endpoint to make sure the services behind the load balancer are alive.

https://jwalab.atlassian.net/browse/BSP-138
https://jwalab.atlassian.net/browse/BSP-139

- [x] add new endpoint
- [x] add test for success
- [ ]  ~~add test for failure~~ see https://jwalab.atlassian.net/browse/BSP-140