### PR TITLE
BSP-248: Ensure HTTP response is the decoded Nats reply

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,12 +3,15 @@ version: "3.8"
 services:
     nats:
         image: nats:latest
-        command: []
+        command: ["-js"]
         ports:
             - "4222:4222"
             - "6222:6222"
             - "8222:8222"
     authorization-service:
-        image: jwalab/authorization-service:latest
+        image: jwalab/authorization-service:0.0.4
         ports:
             - "8999:8999"
+        environment:
+            - TOKEN_ISSUER=localhost
+        restart: always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "airlock",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Airlock is an HTTP<->NATS bridge granting access to the JWA platform's resources",
     "main": "dist/index.js",
     "directories": {

--- a/src/middlewares/natsToRestBridge.ts
+++ b/src/middlewares/natsToRestBridge.ts
@@ -62,7 +62,7 @@ export default function restToNatsBridgeFactory(
                 );
             }
 
-            res.status(200).send(reply.data);
+            res.status(200).send(response);
         } catch (err) {
             if (err.code === ErrorCode.NoResponders) {
                 return next(


### PR DESCRIPTION
- docker-compose.yaml updated.
- natsToRestBridge.ts HTTP response updated.
- Version bump
