### PR TITLE
BSP-258: Airlock errors updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2.1
 orbs:
-    node: circleci/node@4.4.0
+    node: circleci/node@4.7.0
 jobs:
     lint:
-        executor: node/default
+        executor:
+            name: node/default
+            tag: "16.6"
         steps:
             - checkout
             - run: npm install
@@ -11,10 +13,9 @@ jobs:
             - run: npm run lint
     test:
         machine:
-            image: ubuntu-2004:202010-01
+            image: ubuntu-2004:202107-02
         steps:
             - checkout
-            - run: nvm alias default 14.12.0
             - run:
                   command: docker-compose up
                   background: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@jwalab/errors": "0.0.1",
+                "@jwalab/errors": "0.0.2",
                 "@okta/jwt-verifier": "^2.1.0",
                 "body-parser": "^1.19.0",
                 "cookie-parser": "^1.4.5",
@@ -78,6 +78,10 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
             }
         },
         "node_modules/@babel/core/node_modules/semver": {
@@ -327,6 +331,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-bigint": {
@@ -336,6 +343,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-class-properties": {
@@ -345,6 +355,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-import-meta": {
@@ -354,6 +367,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-json-strings": {
@@ -363,6 +379,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -372,6 +391,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -381,6 +403,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -390,6 +415,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-object-rest-spread": {
@@ -399,6 +427,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -408,6 +439,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -417,6 +451,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -426,6 +463,9 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/template": {
@@ -848,9 +888,13 @@
             }
         },
         "node_modules/@jwalab/errors": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@jwalab/errors/-/errors-0.0.1.tgz",
-            "integrity": "sha512-e03b4M6QW12IMVR3g2QG/zVXdHMiDsy1wto68uZX3XttEhGPxBmAg5UVbIWhraB+4lwiiSDEt9EpwZOLdaQD3g=="
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@jwalab/errors/-/errors-0.0.2.tgz",
+            "integrity": "sha512-cWhTGgVTpZGZv2u6zml5k5yQLy3YVsbQvKsBdvuNYnh8DNvW+q3bDMswrx1rMmkHTWf65l3If8jBT9Ou+sgdAg==",
+            "engines": {
+                "node": ">=14",
+                "npm": ">=7.21"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.4",
@@ -1208,6 +1252,19 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^4.0.0",
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@typescript-eslint/experimental-utils": {
@@ -1225,6 +1282,13 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "*"
             }
         },
         "node_modules/@typescript-eslint/parser": {
@@ -1240,6 +1304,18 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -1253,6 +1329,10 @@
             },
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/types": {
@@ -1262,6 +1342,10 @@
             "dev": true,
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
@@ -1281,6 +1365,15 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
@@ -1294,6 +1387,10 @@
             },
             "engines": {
                 "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/abab": {
@@ -1346,7 +1443,10 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
         },
         "node_modules/acorn-walk": {
             "version": "7.2.0",
@@ -1378,6 +1478,10 @@
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/ansi-align": {
@@ -1408,6 +1512,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-escapes/node_modules/type-fest": {
@@ -1417,6 +1524,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
@@ -1437,6 +1547,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/anymatch": {
@@ -1620,6 +1733,9 @@
             },
             "engines": {
                 "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/babel-plugin-istanbul": {
@@ -1671,6 +1787,9 @@
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3",
                 "@babel/plugin-syntax-top-level-await": "^7.8.3"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/babel-preset-jest": {
@@ -1684,6 +1803,9 @@
             },
             "engines": {
                 "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1870,6 +1992,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/boxen/node_modules/chalk": {
@@ -2053,6 +2178,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cacheable-request/node_modules/lowercase-keys": {
@@ -2111,6 +2239,9 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/char-regex": {
@@ -2189,6 +2320,9 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cliui": {
@@ -2552,6 +2686,10 @@
             "dev": true,
             "engines": {
                 "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
             }
         },
         "node_modules/debug": {
@@ -2563,6 +2701,11 @@
             },
             "engines": {
                 "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/decamelize": {
@@ -2815,6 +2958,9 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
             }
         },
         "node_modules/emoji-regex": {
@@ -2898,8 +3044,7 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "optionator": "^0.8.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -2907,6 +3052,9 @@
             },
             "engines": {
                 "node": ">=4.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
             }
         },
         "node_modules/escodegen/node_modules/levn": {
@@ -3009,6 +3157,9 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint-config-prettier": {
@@ -3018,6 +3169,9 @@
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -3043,6 +3197,9 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
@@ -3767,19 +3924,6 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "node_modules/fsevents": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-            "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3864,6 +4008,9 @@
             },
             "engines": {
                 "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -3888,6 +4035,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/global-dirs/node_modules/ini": {
@@ -3906,6 +4056,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globby": {
@@ -3923,6 +4076,9 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/got": {
@@ -3973,6 +4129,7 @@
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
             "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+            "deprecated": "this library is no longer supported",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.3",
@@ -4242,6 +4399,9 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/import-lazy": {
@@ -4384,6 +4544,9 @@
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-data-descriptor": {
@@ -4444,6 +4607,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-extendable": {
@@ -4505,6 +4671,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-npm": {
@@ -4753,6 +4922,9 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -4765,6 +4937,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/jest-changed-files/node_modules/is-stream": {
@@ -4815,6 +4990,14 @@
             },
             "engines": {
                 "node": ">= 10.14.2"
+            },
+            "peerDependencies": {
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ts-node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jest-diff": {
@@ -5028,6 +5211,14 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jest-regex-util": {
@@ -5372,6 +5563,9 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/jest-watcher": {
@@ -5640,6 +5834,14 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "peerDependencies": {
+                "canvas": "^2.5.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jsesc": {
@@ -5987,6 +6189,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/make-dir/node_modules/semver": {
@@ -6371,6 +6576,10 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/nodemon"
             }
         },
         "node_modules/nodemon/node_modules/debug": {
@@ -6585,6 +6794,9 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/openapi-types": {
@@ -6626,6 +6838,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-finally": {
@@ -6646,6 +6861,9 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-locate": {
@@ -6805,6 +7023,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/pify": {
@@ -7255,6 +7476,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/read-pkg-up/node_modules/find-up": {
@@ -7307,6 +7531,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/read-pkg-up/node_modules/path-exists": {
@@ -7374,6 +7601,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mysticatea"
             }
         },
         "node_modules/registry-auth-token": {
@@ -7428,6 +7658,7 @@
             "version": "2.88.2",
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
             "dev": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
@@ -7465,12 +7696,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
             }
         },
         "node_modules/request-promise-native": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
             "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
             "dev": true,
             "dependencies": {
                 "request-promise-core": "1.1.4",
@@ -7479,6 +7714,9 @@
             },
             "engines": {
                 "node": ">=0.12.0"
+            },
+            "peerDependencies": {
+                "request": "^2.34"
             }
         },
         "node_modules/request-promise-native/node_modules/tough-cookie": {
@@ -7511,6 +7749,7 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
             "dev": true,
             "bin": {
                 "uuid": "bin/uuid"
@@ -7548,6 +7787,9 @@
             "dependencies": {
                 "is-core-module": "^2.1.0",
                 "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve-cwd": {
@@ -7584,6 +7826,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "deprecated": "https://github.com/lydell/resolve-url#deprecated",
             "dev": true
         },
         "node_modules/responselike": {
@@ -7624,6 +7867,9 @@
             },
             "bin": {
                 "rimraf": "bin.js"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rsvp": {
@@ -7639,7 +7885,21 @@
             "version": "1.1.10",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
             "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-            "dev": true
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
         },
         "node_modules/rxjs": {
             "version": "6.6.3",
@@ -7676,6 +7936,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
             "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+            "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
             "dev": true,
             "dependencies": {
                 "@cnakazawa/watch": "^1.0.3",
@@ -8037,6 +8298,9 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
@@ -8313,6 +8577,11 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8479,6 +8748,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/supports-color": {
@@ -8536,6 +8808,10 @@
                 "json-schema-traverse": "^1.0.0",
                 "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/table/node_modules/emoji-regex": {
@@ -8592,6 +8868,9 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/terminal-link": {
@@ -8605,6 +8884,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/test-exclude": {
@@ -8738,6 +9020,9 @@
             },
             "bin": {
                 "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/tough-cookie": {
@@ -8791,6 +9076,9 @@
             },
             "engines": {
                 "node": ">= 6"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
         "node_modules/tunnel-agent": {
@@ -9003,6 +9291,9 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/yeoman/update-notifier?sponsor=1"
             }
         },
         "node_modules/update-notifier/node_modules/chalk": {
@@ -9031,6 +9322,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "deprecated": "Please see https://github.com/lydell/urix#deprecated",
             "dev": true
         },
         "node_modules/url-parse-lax": {
@@ -10136,9 +10428,9 @@
             }
         },
         "@jwalab/errors": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@jwalab/errors/-/errors-0.0.1.tgz",
-            "integrity": "sha512-e03b4M6QW12IMVR3g2QG/zVXdHMiDsy1wto68uZX3XttEhGPxBmAg5UVbIWhraB+4lwiiSDEt9EpwZOLdaQD3g=="
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@jwalab/errors/-/errors-0.0.2.tgz",
+            "integrity": "sha512-cWhTGgVTpZGZv2u6zml5k5yQLy3YVsbQvKsBdvuNYnh8DNvW+q3bDMswrx1rMmkHTWf65l3If8jBT9Ou+sgdAg=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
@@ -10583,7 +10875,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -11933,7 +12226,8 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
             "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -12515,13 +12809,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
-        },
-        "fsevents": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-            "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
-            "dev": true,
-            "optional": true
         },
         "function-bind": {
             "version": "1.1.1",
@@ -13639,7 +13926,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "26.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "airlock",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Airlock is an HTTP<->NATS bridge granting access to the JWA platform's resources",
     "main": "dist/index.js",
     "directories": {
@@ -58,7 +58,7 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "@jwalab/errors": "0.0.1",
+        "@jwalab/errors": "0.0.2",
         "@okta/jwt-verifier": "^2.1.0",
         "body-parser": "^1.19.0",
         "cookie-parser": "^1.4.5",

--- a/src/lib/errors/airlockError.ts
+++ b/src/lib/errors/airlockError.ts
@@ -1,0 +1,13 @@
+import { JWAError } from "@jwalab/errors";
+
+export class AirlockError extends JWAError {
+    constructor(
+        name: string,
+        httpCode: number,
+        message: string,
+        errorCode: string
+    ) {
+        super(httpCode, message, errorCode, undefined);
+        this.name = name;
+    }
+}

--- a/src/lib/errors/badRequestError.ts
+++ b/src/lib/errors/badRequestError.ts
@@ -4,7 +4,6 @@ export class BadRequestError extends JWAError {
     constructor(message: string, origin?: Error) {
         super(
             400,
-            BadRequestError.name,
             `Invalid payload. Details: ${message}`,
             "BAD_REQUEST",
             origin

--- a/src/lib/errors/forbiddenRequestError.ts
+++ b/src/lib/errors/forbiddenRequestError.ts
@@ -4,7 +4,6 @@ export class ForbiddenRequestError extends JWAError {
     constructor(message: string, origin?: Error) {
         super(
             403,
-            ForbiddenRequestError.name,
             `This endpoint require further authorizations. Details: ${message}`,
             "AUTH_INVALID_TOKEN",
             origin

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -3,3 +3,4 @@ export * from "./forbiddenRequestError";
 export * from "./notFoundRequestError";
 export * from "./unauthorizedRequestError";
 export * from "./unknownItemError";
+export * from "./airlockError";

--- a/src/lib/errors/notFoundRequestError.ts
+++ b/src/lib/errors/notFoundRequestError.ts
@@ -4,7 +4,6 @@ export class NotFoundRequestError extends JWAError {
     constructor(message: string, origin?: Error) {
         super(
             404,
-            NotFoundRequestError.name,
             `URL Not found. Details: ${message}`,
             "URL_NOT_FOUND",
             origin

--- a/src/lib/errors/unauthorizedRequestError.ts
+++ b/src/lib/errors/unauthorizedRequestError.ts
@@ -4,7 +4,6 @@ export class UnauthorizedRequestError extends JWAError {
     constructor(message: string, origin?: Error) {
         super(
             401,
-            UnauthorizedRequestError.name,
             `This endpoint require an authorization token. Details: ${message}`,
             "AUTH_NOT_AUTHORIZED",
             origin

--- a/src/lib/errors/unknownItemError.ts
+++ b/src/lib/errors/unknownItemError.ts
@@ -4,7 +4,6 @@ export class UnknownItemError extends JWAError {
     constructor(message: string, origin?: Error) {
         super(
             400,
-            UnknownItemError.name,
             `Item does not exists. Details: ${message}`,
             "UNKNOWN_ITEM",
             origin

--- a/src/middlewares/natsToRestBridge.ts
+++ b/src/middlewares/natsToRestBridge.ts
@@ -5,8 +5,7 @@ import {
     headers as natsHeaders
 } from "nats";
 import { NextFunction, Request, Response } from "express";
-import { NotFoundRequestError } from "../lib/errors";
-import { JWAError } from "@jwalab/errors";
+import { AirlockError, NotFoundRequestError } from "../lib/errors";
 
 interface PlatformResponse extends Object {
     error?: string;
@@ -59,7 +58,7 @@ export default function restToNatsBridgeFactory(
                     );
 
                     return next(
-                        new JWAError(httpCode, name, message, errorCode)
+                        new AirlockError(name, httpCode, message, errorCode)
                     );
                 } catch (error) {
                     return next(new Error(response.error));


### PR DESCRIPTION
- Airlock errors updated with new JWAError.
- @jwalab/errors package updated to 0.0.2 with new JWAError and name-less contructor.
- CircleCI updated to 202107-02 for NPM 7 & Lockfile2.0 support.

